### PR TITLE
Remove inheritance from object

### DIFF
--- a/piper/abc.py
+++ b/piper/abc.py
@@ -2,7 +2,7 @@ import logbook
 import jsonschema
 
 
-class DynamicItem(object):
+class DynamicItem:
     """
     Dynamic base class that defines things all Piper classes need.
 

--- a/piper/build.py
+++ b/piper/build.py
@@ -260,7 +260,7 @@ class Build(LazyDatabaseMixin):
         self.db.agent.unlock(self)
 
 
-class ExecCLI(object):
+class ExecCLI:
     def __init__(self, config):
         self.config = config
 

--- a/piper/cli/cli.py
+++ b/piper/cli/cli.py
@@ -5,7 +5,7 @@ import logbook
 from piper import logging
 
 
-class CLI(object):
+class CLI:
     """
     Semi-abstract class that sets up a argparse namespace and executes
     commands from pluggable CLI classes.

--- a/piper/config.py
+++ b/piper/config.py
@@ -35,7 +35,7 @@ class ConfigError(Exception):
     pass
 
 
-class Config(object):
+class Config:
     def __init__(self, filename=None, raw=None):
         args = (filename, raw)
         assert any(args), 'Need to specify `filename` or `raw`'

--- a/piper/db/core.py
+++ b/piper/db/core.py
@@ -1,7 +1,7 @@
 import logbook
 
 
-class LazyDatabaseMixin(object):
+class LazyDatabaseMixin:
     """
     A mixin class that gives the subclass lazy access to the database layer
 
@@ -30,7 +30,7 @@ class LazyDatabaseMixin(object):
     db = property(_get_db, _set_db)
 
 
-class AgentManager(object):
+class AgentManager:
     def get(self):
         """
         Lazily get an agent.
@@ -59,7 +59,7 @@ class AgentManager(object):
         raise NotImplementedError()
 
 
-class BuildManager(object):
+class BuildManager:
     def add(self, build):
         """
         Register a build to the database.
@@ -111,7 +111,7 @@ class BuildManager(object):
         raise NotImplementedError()
 
 
-class ConfigManager(object):
+class ConfigManager:
     def register(self, build):
         """
         Register a configuration to the database.
@@ -121,7 +121,7 @@ class ConfigManager(object):
         raise NotImplementedError()
 
 
-class ProjectManager(object):
+class ProjectManager:
     def get(self, build):
         """
         Lazily get the project.
@@ -134,7 +134,7 @@ class ProjectManager(object):
         raise NotImplementedError()
 
 
-class VCSManager(object):
+class VCSManager:
     def get(self, build):
         """
         Lazily get the VCS.
@@ -144,7 +144,7 @@ class VCSManager(object):
         raise NotImplementedError()
 
 
-class PropertyManager(object):
+class PropertyManager:
     def update(self):
         """
         Update agent properties.
@@ -154,11 +154,11 @@ class PropertyManager(object):
         raise NotImplementedError()
 
 
-class PropertyNamespaceManager(object):
+class PropertyNamespaceManager:
     pass
 
 
-class Database(object):
+class Database:
     """
     Abstract class representing a persistance layer
 

--- a/piper/db/db_sqlalchemy.py
+++ b/piper/db/db_sqlalchemy.py
@@ -28,7 +28,7 @@ Base = declarative_base()
 Session = sessionmaker()
 
 
-class SQLAlchemyManager(object):
+class SQLAlchemyManager:
     def __init__(self, db):
         self.db = db
 

--- a/piper/logging.py
+++ b/piper/logging.py
@@ -50,7 +50,7 @@ DEFAULT_LOGFILE_FORMAT_STRING = (
 SEPARATOR = ': '
 
 
-class Colorizer(object):
+class Colorizer:
     terminal = blessings.Terminal()
 
     def __init__(self, regexp, formatting, aborting=False, flags=0):

--- a/piper/process.py
+++ b/piper/process.py
@@ -4,7 +4,7 @@ import sh
 from piper.logging import SEPARATOR
 
 
-class Process(object):
+class Process:
     """
     Helper class for running processes
 

--- a/piper/prop.py
+++ b/piper/prop.py
@@ -17,7 +17,7 @@ class PropValidationError(Exception):
         super(PropValidationError, self).__init__(self.msg)
 
 
-class PropSource(object):
+class PropSource:
     def __init__(self):
         self._props = None
 

--- a/piper/vcs.py
+++ b/piper/vcs.py
@@ -3,7 +3,7 @@ import logbook
 from piper import utils
 
 
-class VCS(object):
+class VCS:
     def __init__(self, name, root_url):
         self.name = name
         self.root_url = root_url

--- a/test/api/test_api.py
+++ b/test/api/test_api.py
@@ -3,7 +3,7 @@ from piper.api.api import ApiCLI
 import mock
 
 
-class TestApiCLISetup(object):
+class TestApiCLISetup:
     def setup_method(self, method):
         self.config = mock.Mock()
 
@@ -72,7 +72,7 @@ class TestApiCLISetup(object):
         self.assert_config()
 
 
-class TestApiCLIPatchJson(object):
+class TestApiCLIPatchJson:
     def setup_method(self, method):
         self.cli = ApiCLI(mock.Mock())
         self.cli.db = mock.Mock()
@@ -83,7 +83,7 @@ class TestApiCLIPatchJson(object):
         rj.settings.update.assert_called_once_with(self.cli.db.json_settings)
 
 
-class TestApiCLIRun(object):
+class TestApiCLIRun:
     def setup_method(self, method):
         self.config = mock.Mock()
 

--- a/test/api/test_build.py
+++ b/test/api/test_build.py
@@ -4,7 +4,7 @@ from piper.api.build import Build
 from piper.api.build import BuildList
 
 
-class TestBuildGet(object):
+class TestBuildGet:
     def setup_method(self, method):
         self.build = Build()
         self.build.db = mock.Mock()
@@ -24,7 +24,7 @@ class TestBuildGet(object):
         assert code == 404
 
 
-class TestBuildListGet(object):
+class TestBuildListGet:
     def setup_method(self, method):
         self.buildlist = BuildList()
         self.buildlist.db = mock.Mock()

--- a/test/cli/test_cli.py
+++ b/test/cli/test_cli.py
@@ -4,7 +4,7 @@ import logbook
 import mock
 
 
-class TestCLIEntry(object):
+class TestCLIEntry:
     def setup_method(self, method):
         self.cli = CLI('test', (mock.Mock(),), mock.Mock())
 
@@ -45,7 +45,7 @@ class TestCLIEntry(object):
         self.parser.print_help.assert_called_once_with()
 
 
-class TestCLIBuildParser(object):
+class TestCLIBuildParser:
     def setup_method(self, method):
         self.name = 'ophelia',
         self.classes = (mock.Mock(), mock.Mock())
@@ -77,7 +77,7 @@ class TestCLIBuildParser(object):
         )
 
 
-class TestCLIGetRunners(object):
+class TestCLIGetRunners:
     def setup_method(self, method):
         self.name = 'kai',
 
@@ -105,7 +105,7 @@ class TestCLIGetRunners(object):
             cls.return_value.compose.assert_called_once_with(self.sub)
 
 
-class TestCLISetDebug(object):
+class TestCLISetDebug:
     def setup_method(self, method):
         self.cli = CLI('test', (mock.Mock(),), mock.Mock())
         self.cli.log_handlers = mock.Mock(), mock.Mock(), mock.Mock()

--- a/test/cli/test_cmd_piper.py
+++ b/test/cli/test_cmd_piper.py
@@ -7,7 +7,7 @@ from piper.cli.cli import CLI
 import mock
 
 
-class TestEntry(object):
+class TestEntry:
     @mock.patch('piper.cli.cmd_piper.CLI')
     def test_calls(self, clibase):
         self.mock = mock.Mock()
@@ -26,7 +26,7 @@ class TestEntry(object):
         assert ret is clibase.return_value.entry.return_value
 
 
-class TestEntryIntegration(object):
+class TestEntryIntegration:
     def test_db_init(self):
         args = ['db', 'init']
         cli = CLI('piper', (db.DbCLI,), config.BuildConfig, args=args)

--- a/test/cli/test_cmd_piperd.py
+++ b/test/cli/test_cmd_piperd.py
@@ -7,7 +7,7 @@ from piper import config
 import mock
 
 
-class TestEntry(object):
+class TestEntry:
     @mock.patch('piper.cli.cmd_piperd.CLI')
     def test_calls(self, clibase):
         self.mock = mock.Mock()
@@ -26,7 +26,7 @@ class TestEntry(object):
         assert ret is clibase.return_value.entry.return_value
 
 
-class TestEntryIntegration(object):
+class TestEntryIntegration:
     @mock.patch('piper.api.api.Flask')
     def test_api_start(self, flask):
         cmd_piperd.entry(['api', 'start'])

--- a/test/db/test_core.py
+++ b/test/db/test_core.py
@@ -7,7 +7,7 @@ from piper.db.core import DbCLI
 from piper.db.core import Database
 
 
-class DbCLITest(object):
+class DbCLITest:
     def setup_method(self, method):
         self.config = mock.Mock()
         self.cli = DbCLI(self.config)
@@ -23,7 +23,7 @@ class TestDbCLIRun(DbCLITest):
         self.cli.db.init.assert_called_once_with(self.config)
 
 
-class TestDatabase(object):
+class TestDatabase:
     def setup_method(self, method):
         self.db = Database()
 
@@ -54,7 +54,7 @@ class TestDatabase(object):
         self.missing('property', 'update')
 
 
-class TestLazyDatabaseMixinDb(object):
+class TestLazyDatabaseMixinDb:
     def setup_method(self, method):
         self.ldm = LazyDatabaseMixin()
 

--- a/test/db/test_db_sqlalchemy.py
+++ b/test/db/test_db_sqlalchemy.py
@@ -25,7 +25,7 @@ import mock
 import pytest
 
 
-class ManagerTest(object):
+class ManagerTest:
     def setup_method(self, method):
         self.db = mock.Mock(_session=None)
         self.build = mock.Mock()
@@ -530,7 +530,7 @@ class TestSQLAlchemyDBSetupManagers(SQLATest):
         assert self.db.hehe is manager.return_value
 
 
-class TestSQLAlchemyManagerGetOrCreate(object):
+class TestSQLAlchemyManagerGetOrCreate:
     def setup_method(self, method):
         self.manager = SQLAlchemyManager(mock.Mock())
         self.session = mock.Mock()
@@ -573,7 +573,7 @@ class TestSQLAlchemyManagerGetOrCreate(object):
         self.filter.assert_called_once_with(**self.filtered_keys)
 
 
-class TestSQLAlchemyManagerInSession(object):
+class TestSQLAlchemyManagerInSession:
     def setup_method(self, method):
         self.db = mock.Mock(_session=None)
         self.sql = SQLAlchemyManager(self.db)

--- a/test/test_abc.py
+++ b/test/test_abc.py
@@ -5,7 +5,7 @@ import mock
 import pytest
 
 
-class TestDynamicItemValidateRequirements(object):
+class TestDynamicItemValidateRequirements:
     def setup_method(self, method):
         self.build = mock.Mock()
 

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -8,7 +8,7 @@ from test.utils import BASE_CONFIG
 from test.utils import SQLAIntegration
 
 
-class BuildTest(object):
+class BuildTest:
     def setup_method(self, method):
         self.build = Build(mock.MagicMock())
         self.base_config = BASE_CONFIG
@@ -67,7 +67,7 @@ class TestBuildRun(BuildTest):
         assert ret is True
 
 
-class TestBuildSetVersion(object):
+class TestBuildSetVersion:
     def setup_method(self, method):
         self.version = '0.0.0.0.0.0.0.0.1-beta'
         self.cls = mock.Mock()
@@ -91,7 +91,7 @@ class TestBuildSetVersion(object):
         self.cls.return_value.validate.assert_called_once_with()
 
 
-class TestBuildConfigureEnv(object):
+class TestBuildConfigureEnv:
     def setup_method(self, method):
         env_key = 'local'
         self.cls_key = 'unisonic.KingForADay'
@@ -120,7 +120,7 @@ class TestBuildConfigureEnv(object):
         self.cls.return_value.validate.assert_called_once_with()
 
 
-class TestBuildConfigureSteps(object):
+class TestBuildConfigureSteps:
     def setup_method(self, method):
         self.step_key = 'local'
         self.raw = {
@@ -158,7 +158,7 @@ class TestBuildConfigureSteps(object):
             cls.return_value.validate.assert_called_once_with()
 
 
-class TestBuildConfigurePipeline(object):
+class TestBuildConfigurePipeline:
     def setup_method(self, method):
         self.step_keys = ('bidubidappa', 'dubop', 'schuwappa')
         self.pipeline_key = 'mmmbop'
@@ -187,7 +187,7 @@ class TestBuildConfigurePipeline(object):
             assert self.build.order[x] is self.steps[x]
 
 
-class TestBuildExecute(object):
+class TestBuildExecute:
     def setup_method(self, method):
         self.build = Build(mock.Mock())
         self.build.order = [mock.Mock() for _ in range(3)]
@@ -320,7 +320,7 @@ class TestBuildUnlockAgent(BuildTest):
         self.build.db.agent.unlock.assert_called_once_with(self.build)
 
 
-class TestExecCLIRun(object):
+class TestExecCLIRun:
     def setup_method(self, method):
         self.config = mock.Mock()
         self.cli = ExecCLI(self.config)

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -12,7 +12,7 @@ from piper.config import AgentConfig
 from test import utils
 
 
-class BuildConfigTest(object):
+class BuildConfigTest:
     def setup_method(self, method):
         self.config = BuildConfig()
         # Without the deepcopy the tests that check for missing keys will
@@ -20,13 +20,13 @@ class BuildConfigTest(object):
         self.base_config = copy.deepcopy(utils.BASE_CONFIG)
 
 
-class AgentConfigTest(object):
+class AgentConfigTest:
     def setup_method(self, method):
         self.config = AgentConfig()
         self.config.raw = copy.deepcopy(utils.AGENT_CONFIG)
 
 
-class TestConfigLoad(object):
+class TestConfigLoad:
     def test_raw_configuration(self):
         self.raw = {
             'tiger army': 'pain',
@@ -41,7 +41,7 @@ class TestConfigLoad(object):
         assert self.config.raw == self.raw
 
 
-class TestConfigCollectClasses(object):
+class TestConfigCollectClasses:
     def test_load_classes_loads_nested(self):
         self.raw = {
             'avantasia': {
@@ -182,7 +182,7 @@ class TestBuildConfigMergeNamespace(BuildConfigTest):
         self.correct = 'happy for the rest of your life'
 
         # Can't use mocks because they have, like, a million properties.
-        class FakeNS(object):
+        class FakeNS:
             key = self.correct
             _internal = 'never make a pretty woman your wife'
 

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -8,7 +8,7 @@ from piper.env import TempDirEnv
 from test.utils import BASE_CONFIG
 
 
-class EnvTest(object):
+class EnvTest:
     def setup_method(self, method):
         self.build = mock.Mock()
         self.env = Env(self.build, BASE_CONFIG['envs']['local'])
@@ -42,7 +42,7 @@ class TestEnvExecute(EnvTest):
         assert ret is procobj
 
 
-class TestTempDirEnvSetup(object):
+class TestTempDirEnvSetup:
     def setup_method(self, method):
         self.build = mock.Mock()
         self.env = TempDirEnv(self.build, mock.MagicMock())
@@ -68,7 +68,7 @@ class TestTempDirEnvSetup(object):
             self.env.validate()
 
 
-class TestTempDirEnvTeardown(object):
+class TestTempDirEnvTeardown:
     def setup_method(self, method):
         self.build = mock.Mock()
         self.env = TempDirEnv(self.build, mock.MagicMock())
@@ -90,7 +90,7 @@ class TestTempDirEnvTeardown(object):
         assert rmtree.call_count == 0
 
 
-class TestTempDirEnvExecute(object):
+class TestTempDirEnvExecute:
     def setup_method(self, method):
         self.build = mock.Mock()
         self.env = TempDirEnv(self.build, mock.MagicMock())

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -5,7 +5,7 @@ from piper.logging import SEPARATOR
 import mock
 
 
-class TestBlessingsStringFormatterColorize(object):
+class TestBlessingsStringFormatterColorize:
     def setup_method(self, method):
         self.color = 'color_code'
         self.string = 'mock'
@@ -47,7 +47,7 @@ class TestBlessingsStringFormatterColorize(object):
         assert md5.call_count == 1
 
 
-class TestBlessingsStringFormatterFormatRecord(object):
+class TestBlessingsStringFormatterFormatRecord:
     def setup_method(self, method):
         color = 'black'
         channel = 'no{0}return'.format(SEPARATOR)
@@ -84,7 +84,7 @@ class TestBlessingsStringFormatterFormatRecord(object):
         self.bsf._formatter.format.assert_called_once_with(**self.kwargs)
 
 
-class TestBlessingsStringFormatterPrepareRecord(object):
+class TestBlessingsStringFormatterPrepareRecord:
     def setup_method(self, method):
         self.rc = mock.Mock()
         self.colorizer = mock.Mock()
@@ -101,7 +101,7 @@ class TestBlessingsStringFormatterPrepareRecord(object):
         assert self.colorizer.colorize.call_count == 1
 
 
-class TestColorizerColorize(object):
+class TestColorizerColorize:
     def test_stop_if_no_matches(self):
         color = Colorizer('regexp', 'replace')
         done, ret = color.colorize('message')

--- a/test/test_process.py
+++ b/test/test_process.py
@@ -5,7 +5,7 @@ from piper.process import Process
 import mock
 
 
-class TestProcessSetup(object):
+class TestProcessSetup:
     def setup_method(self, method):
         self.proc = Process(mock.Mock(), '/usr/bin/empathy world hide', 'key')
 
@@ -16,7 +16,7 @@ class TestProcessSetup(object):
         assert sh_mock.called_once_with('/usr/bin/empathy')
 
 
-class TestProcessRun(object):
+class TestProcessRun:
     def test_run_failure(self):
         self.proc = Process(mock.Mock(), 'ls -l', 'oioi')
         self.proc.sh = mock.MagicMock()

--- a/test/test_prop.py
+++ b/test/test_prop.py
@@ -8,7 +8,7 @@ from piper.prop import PropCLI
 from piper.prop import PropValidationError
 
 
-class PropTest(object):
+class PropTest:
     def setup_method(self, method):
         self.key = 'nocturnal.rites'
         self.value = 'awakening'
@@ -17,13 +17,13 @@ class PropTest(object):
         self.prop.db = mock.Mock()
 
 
-class PropSourceTest(object):
+class PropSourceTest:
     def setup_method(self, method):
         self.build = mock.Mock()
         self.prop = PropSource()
 
 
-class PropCLITest(object):
+class PropCLITest:
     def setup_method(self, method):
         self.config = mock.Mock()
         self.cli = PropCLI(self.config)
@@ -155,7 +155,7 @@ class TestPropSourceFlatten(PropSourceTest):
         }
 
 
-class TestFacterPropGenerate(object):
+class TestFacterPropGenerate:
     @mock.patch('piper.prop.FacterProp')
     @mock.patch('facter.Facter')
     def test_generate(self, Facter, FacterProp):

--- a/test/test_step.py
+++ b/test/test_step.py
@@ -5,7 +5,7 @@ import mock
 import pytest
 
 
-class StepTest(object):
+class StepTest:
     def setup_method(self, method):
         self.build = mock.Mock()
         self.key = 'test'
@@ -21,7 +21,7 @@ class StepTest(object):
         self.step = Step(self.build, self.schema, self.key)
 
 
-class CommandLineStepTest(object):
+class CommandLineStepTest:
     def setup_method(self, method):
         self.build = mock.Mock()
         self.key = 'test'

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -5,7 +5,7 @@ from piper.utils import oneshot
 import pytest
 
 
-class TestDynamicLoad(object):
+class TestDynamicLoad:
     def test_proper_load(self):
         cls = dynamic_load('piper.utils.LimitedSizeDict')
         assert cls is LimitedSizeDict
@@ -15,7 +15,7 @@ class TestDynamicLoad(object):
             dynamic_load('gammaray.empire.Avalon')
 
 
-class TestOneshot(object):
+class TestOneshot:
     def test_execution(self):
         ret = oneshot('echo lolz')
         assert ret == 'lolz'

--- a/test/test_vcs.py
+++ b/test/test_vcs.py
@@ -5,7 +5,7 @@ from piper.vcs import VCS
 from piper.vcs import GitVCS
 
 
-class VCSTest(object):
+class VCSTest:
     def setup_method(self, method):
         self.vcs = VCS('name', 'root')
         self.project = 'bourne'
@@ -26,7 +26,7 @@ class TestVCSGetProjectName(VCSTest):
         self.missing('get_project_name', self.project)
 
 
-class TestGitVCSGetProjectName(object):
+class TestGitVCSGetProjectName:
     def setup_method(self, method):
         self.git = GitVCS('horny', 'hearse')
 

--- a/test/test_version.py
+++ b/test/test_version.py
@@ -7,7 +7,7 @@ import pytest
 import mock
 
 
-class StaticVersionTest(object):
+class StaticVersionTest:
     def setup_method(self, method):
         self.build = mock.Mock()
         self.v = '32.1.12'
@@ -18,7 +18,7 @@ class StaticVersionTest(object):
         self.version = StaticVersion(self.build, self.raw)
 
 
-class GitVersionTest(object):
+class GitVersionTest:
     def setup_method(self, method):
         self.build = mock.Mock()
         self.raw = {
@@ -27,14 +27,14 @@ class GitVersionTest(object):
         self.git = GitVersion(self.build, self.raw)
 
 
-class TestVersionValidate(object):
+class TestVersionValidate:
     def test_broken_schema(self):
         version = Version(mock.Mock(), mock.Mock(the_final_countdown=True))
         with pytest.raises(jsonschema.exceptions.ValidationError):
             version.validate()
 
 
-class TestVersionGetVersion(object):
+class TestVersionGetVersion:
     def test_not_implemented(self):
         version = Version(mock.Mock(), mock.Mock())
         with pytest.raises(NotImplementedError):

--- a/test/utils.py
+++ b/test/utils.py
@@ -11,7 +11,7 @@ with open('piperd.yml') as f:
     AGENT_CONFIG = yaml.safe_load(f.read())
 
 
-class SQLATest(object):
+class SQLATest:
     """
     Test base for tests that want a database setup
 


### PR DESCRIPTION
All classes in Python 3 are new style classes, no need for the inheritance from object anymore.

Mentions #25
